### PR TITLE
Github Action to label issues as "Hacktoberfest"

### DIFF
--- a/.github/hacktoberfest_issues_labeler.yml
+++ b/.github/hacktoberfest_issues_labeler.yml
@@ -1,0 +1,4 @@
+Hacktoberfest:
+  - "( )"
+
+  # Added on space as the action should label ALL issues as Hacktoberfest as per issue description

--- a/.github/issues_labeler.yml
+++ b/.github/issues_labeler.yml
@@ -11,18 +11,18 @@ enhancement:
 CH20:
   - "(CH20)"
 Easy:
-  - "(Easy|easy)"  
+  - "(Easy|easy)"
 Medium:
   - "(Medium|medium)"
 Hard:
   - "(Hard|hard)"
 bug:
-  - "(bug|Bug|BUG)"  
+  - "(bug|Bug|BUG)"
 Up-For-Grab:
-  - "(up for grab)"  
+  - "(up for grab)"
 Urgent:
-  - "(urgent|URGENT|Urgent)"  
+  - "(urgent|URGENT|Urgent)"
 documentation:
   - "(documentation)"
 No-Code:
-  - "(No Code)"  
+  - "(No Code)"

--- a/.github/workflows/label_issues_hacktoberfest.yml
+++ b/.github/workflows/label_issues_hacktoberfest.yml
@@ -1,0 +1,17 @@
+name: "Label Hacktoberfest Issues"
+
+on:
+  issues:
+    types: [opened, edited, unlabeled]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v2.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/hacktoberfest_issues_labeler.yml
+          not-before: 2020-10-01
+          not-after: 2020-10-31
+          enable-versioned-regex: 0


### PR DESCRIPTION
# Description

The Action adds the "Hacktoberfest" tag on every newly opened issue when the time frame is between the 1st and 31st of October. I put the value as empty space for the key Hacktoberfest, just to accommodate all issues to get this label.
This is my first time contributing to this repo. So if there is something wrong/to be done, let me know. 

Fixes #(#382 )

## Type of change

_Please delete options that are not relevant._

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines(Clean Code) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have created a helpful and easy to understand `README.md`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests/screenshots(if any) that prove my fix is effective or that my feature works
