### PR TITLE
Updated .gitignore for JetBrains IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,9 +73,6 @@ __pycache__/
 *.py[cod]
 *$py.class
 
-# C extensions
-*.so
-
 # Distribution / packaging
 .Python
 build/
@@ -199,6 +196,50 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+## JetBrains IDE ## (IntelliJ, PyCharm)
+
+# Global
+.idea/
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Auto-imports (Can lead to churn if not ignored)
+.idea/artifacts
+.idea/compiler.xml
+.idea/jarRepositories.xml
+.idea/modules.xml
+.idea/*.iml
+.idea/modules
+*.iml
+*.ipr
+
+# IntelliJ
+out/
+
+# CMake
+cmake-build-*/
 
 # pytype static type analyzer
 .pytype/


### PR DESCRIPTION
# Description

For a contributor who uses *PyCharm* or *IntelliJ IDEA* by **JetBrains** as their primary IDE for Python and Java, made some minor changes in `.gitignore` so that IDE generated files are ignored.

Fixes #468 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines(Clean Code) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have created a helpful and easy to understand `README.md`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests/screenshots(if any) that prove my fix is effective or that my feature works
