### PR TITLE
Removed .DS_Store from everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,9 +41,13 @@
 
 ### macOS ###
 # General
+._.DS_Store
 .DS_Store
 .AppleDouble
 .LSOverride
+.DS_Store?
+**/.DS_Store
+**/._.DS_Store
 
 # Icon must end with two \r
 Icon


### PR DESCRIPTION
# Description

`.DS_Store` (A Mac OS file) has been removed from everywhere. Moreover, I made sure that it would also not pop up in a Sub-Directory in any case.

Fixes #527 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation Update


