### PR TITLE
The /assign action

### DIFF
--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -1,0 +1,25 @@
+name: Assign
+
+on:
+  schedule:
+    - cron: '*/59 * * * *'
+  issue_comment:
+    types: [created]
+
+jobs:
+  slash_assign:
+    # If the acton was triggered by a new comment that starts with `/assign`
+    # or a on a schedule
+    if: >
+      (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/assign')) ||
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign the user or unassign stale assignments
+        uses: JasonEtco/slash-assign-action@v0.0.3
+        with:
+          required_label: Up-For-Grab
+          assigned_label: Assigned
+          days_until_warning: 7
+          days_until_unassign: 14
+          stale_assignment_label: Open


### PR DESCRIPTION
# Description

Probably the biggest thing I ever made.

Here is how it works

- `/assign` assigns the issue to the one who commented.
- Action won't work on an issue which has been assigned
- After 14 days a warning is sent to the person regarding a stale issue
- after 21 days, the person is unassigned and the issue is open again
- it open with an `open` label, will change it in a further update

Fixes #372
Fixes #531 

After the Pilot run, don't forget to make changes to the Issue template

## Type of change


- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

