### PR TITLE
created .gitattributes, resolving #809

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-vendored


### PR DESCRIPTION
# Description

Created .gitattributes and added `*.ipynb linguist-vendored` to the file, to prevent github from categorizing the `Rotten-Scripts` as a jupiter notebook

Fixes #809

## Type of change

Add a .gitattributes file

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines(Clean Code) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have created a helpful and easy to understand `README.md`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests/screenshots(if any) that prove my fix is effective or that my feature works
