### PR TITLE
Add script to auto update readme by recent hashnode blogs

### DIFF
--- a/JavaScript/Update_README_With_Hashnode_Blogs/DemoREADME.md
+++ b/JavaScript/Update_README_With_Hashnode_Blogs/DemoREADME.md
@@ -1,0 +1,7 @@
+## This Point Won't Be Edited
+
+## Latest Blogs
+
+- This will be edited
+
+## This Point Won't Be Edited

--- a/JavaScript/Update_README_With_Hashnode_Blogs/README.md
+++ b/JavaScript/Update_README_With_Hashnode_Blogs/README.md
@@ -1,3 +1,9 @@
+# About
+
+This script helps to show recent blogs published by anyone in **Hashnode** on [GitHub Profile README.md](https://docs.github.com/en/github/setting-up-and-managing-your-github-profile/managing-your-profile-readme). The main benefit of using the script is the whole README.md won't be updated. It will update only what you select to update. So, you can use it to update any place of your README.md by blogs. The script won't update the README.md unnecessarily when it will be scheduled to run. If any differences are found from the current version of README.md only then it will update that differenced portions only.
+
+This script is not limited to use in `GitHub Profile README.md` only, it can be customized and in use other places too.
+
 # Initial Setup
 
 - Create a folder name `.github`
@@ -22,28 +28,29 @@ But modifying **cron** schedule is little bit tricky for beginners. Go to [cront
 🔥🔥
 
 ```js
-//in update_readme.jsline 34
+//in update_readme.jsline 58
 /(?<=Latest Blogs\n)[\s\S]*(?=\#\#\ This Point Won't Be Edited)/gim,
 ```
 
 This is very important thing. Used regular expression so that script modify only the necessary part not the whole `README.md`. If you want to write other things instead of **Latest Blogs** (EX: My Blogs) you have to modify regular expressions like `/(?<=My Blogs\n)[\s\S]*(?=\#\#\ This Point Won't Be Edited)/gim,`
-Next most important thing is upto which point will be replaced. Suppose you have a Section My Blogs & # Skills, you want to replace texts between them then you have to modify like this `/(?<=My Blogs\n)[\s\S]*(?=\#\ Skills)/gim,` .
+Next most important thing is upto which point will be updated. Suppose you have a Section My Blogs & # Skills, you want to update texts between them then you have to modify like this `/(?<=My Blogs\n)[\s\S]*(?=\#\ Skills)/gim,` .
+
 ⚡️ For the starting point (here `My Blogs`) doesn't need to consider what is before it like ##My Blogs or ##### MY Blogs etc.
 If you are beginner in regular expression [RegExr](https://regexr.com/) will help you.
 
 - Go to [RegExr](https://regexr.com/)
 - Paste your `README.md` text below text section
 - Paste the `/(?<=Latest Blogs\n)[\s\S]*(?=\#\#\ This Point Won't Be Edited)/gim` under expression
-- Change those mentioned changes and see which texts are selcted those texts will be replaced.
+- Change those mentioned changes and see which portions are selcted those portions will be updated if found any changes.
 
 🔥🔥🔥
-Current script set to show 3 latest posts if you want to set more than three then change these lines
+Current script set to show 3 latest posts if you want to set more than three then change these lines.
 
 ```js
 //If you want to set 5 posts
-const posts = response.data.user.publication.posts.slice(0, 5); //in update_readme.js, line 25
-//in update_readme.js, line 26
-const postsToShow = `\n - [${posts[0].title}](<you hashnode blog URL>/${posts[0].slug})\n - [${posts[1].title}](<you hashnode blog URL>/${posts[1].slug})\n - [${posts[2].title}](<you hashnode blog URL>/${posts[2].slug})\n - [${posts[3].title}](<you hashnode blog URL>/${posts[3].slug})\n - [${posts[4].title}](<you hashnode blog URL>/${posts[4].slug})\n\n`;
+const numberOfPosts = 5; //in update_readme.js <- line 3
 ```
 
-🌟️ Check demo [update_readme.js](https://paste.ubuntu.com/p/rXN9DwcBPR/)
+⚠️ At the time of writing this, **Hashnode API** gives max latest 6 blogs properties as a response.
+
+🌟️ Check demo [update_readme.js](https://pastebin.ubuntu.com/p/96kCqgmPK6/)

--- a/JavaScript/Update_README_With_Hashnode_Blogs/README.md
+++ b/JavaScript/Update_README_With_Hashnode_Blogs/README.md
@@ -1,0 +1,49 @@
+# Initial Setup
+
+- Create a folder name `.github`
+- Create a folder name `workflows` inside `.github`
+- Copy the file `recent_blogs.yml` to the `workflows` folder
+- Copy the `update_readme.js` file to the root folder
+- Copy the text of `DemoReadMe.md` to your `README.md` and place it any where
+
+# Modification
+
+🔥
+Currently set to check for new blogs for every 5 hour. If you are not happy with it you can modify it.
+
+`recent_blogs.yml` line 6
+
+```yml
+- cron: "* */5 * * *"
+```
+
+But modifying **cron** schedule is little bit tricky for beginners. Go to [crontab guru](https://crontab.guru/), you will be able to change **cron** schedule very easily
+
+🔥🔥
+
+```js
+//in update_readme.jsline 34
+/(?<=Latest Blogs\n)[\s\S]*(?=\#\#\ This Point Won't Be Edited)/gim,
+```
+
+This is very important thing. Used regular expression so that script modify only the necessary part not the whole `README.md`. If you want to write other things instead of **Latest Blogs** (EX: My Blogs) you have to modify regular expressions like `/(?<=My Blogs\n)[\s\S]*(?=\#\#\ This Point Won't Be Edited)/gim,`
+Next most important thing is upto which point will be replaced. Suppose you have a Section My Blogs & # Skills, you want to replace texts between them then you have to modify like this `/(?<=My Blogs\n)[\s\S]*(?=\#\ Skills)/gim,` .
+⚡️ For the starting point (here `My Blogs`) doesn't need to consider what is before it like ##My Blogs or ##### MY Blogs etc.
+If you are beginner in regular expression [RegExr](https://regexr.com/) will help you.
+
+- Go to [RegExr](https://regexr.com/)
+- Paste your `README.md` text below text section
+- Paste the `/(?<=Latest Blogs\n)[\s\S]*(?=\#\#\ This Point Won't Be Edited)/gim` under expression
+- Change those mentioned changes and see which texts are selcted those texts will be replaced.
+
+🔥🔥🔥
+Current script set to show 3 latest posts if you want to set more than three then change these lines
+
+```js
+//If you want to set 5 posts
+const posts = response.data.user.publication.posts.slice(0, 5); //in update_readme.js, line 25
+//in update_readme.js, line 26
+const postsToShow = `\n - [${posts[0].title}](<you hashnode blog URL>/${posts[0].slug})\n - [${posts[1].title}](<you hashnode blog URL>/${posts[1].slug})\n - [${posts[2].title}](<you hashnode blog URL>/${posts[2].slug})\n - [${posts[3].title}](<you hashnode blog URL>/${posts[3].slug})\n - [${posts[4].title}](<you hashnode blog URL>/${posts[4].slug})\n\n`;
+```
+
+🌟️ Check demo [update_readme.js](https://paste.ubuntu.com/p/rXN9DwcBPR/)

--- a/JavaScript/Update_README_With_Hashnode_Blogs/recent_blogs.yml
+++ b/JavaScript/Update_README_With_Hashnode_Blogs/recent_blogs.yml
@@ -1,0 +1,26 @@
+name: README Update By Latest Blogs
+
+on:
+  schedule:
+    #scheduled for every 5 hour
+    - cron: "* */5 * * *"
+
+jobs:
+  perform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "14.x"
+      - run: npm install node-fetch
+      - name: Run script
+        run: node update_readme.js
+      - name: Commit and push if changed
+        run: |
+          git add README.md
+          git diff
+          git config --global user.email "hashnode-bot@example.com"
+          git config --global user.name "Hashnode Bot"
+          git commit -m "Update README with latest blog" -a || echo "No changes to commit"
+          git push

--- a/JavaScript/Update_README_With_Hashnode_Blogs/update_readme.js
+++ b/JavaScript/Update_README_With_Hashnode_Blogs/update_readme.js
@@ -1,0 +1,44 @@
+const fetch = require("node-fetch");
+const fs = require("fs");
+const query = `
+    {
+      user(username: "<your Hashnode username>") {
+        publication {
+          posts{
+            slug
+            title
+          }
+        }
+      }
+    }
+  `;
+
+const fetchPosts = async () => {
+  const result = await fetch("https://api.hashnode.com", {
+    method: "POST",
+    headers: {
+      "Content-type": "application/json",
+    },
+    body: JSON.stringify({ query }),
+  });
+  const response = await result.json();
+  const posts = response.data.user.publication.posts.slice(0, 3);
+  const postsToShow = `\n - [${posts[0].title}](<you hashnode blog URL>/${posts[0].slug})\n - [${posts[1].title}](<you hashnode blog URL>/${posts[1].slug})\n - [${posts[2].title}](<you hashnode blog URL>/${posts[2].slug})\n\n`;
+  fs.readFile("README.md", "utf-8", (err, data) => {
+    if (err) {
+      throw err;
+    }
+    console.log(postsToShow);
+    const updatedMd = data.replace(
+      // To replace texts or blogs between Latest Blogs and Contributors Section
+      /(?<=Latest Blogs\n)[\s\S]*(?=\#\#\ This Point Won't Be Edited)/gim,
+      postsToShow
+    );
+    fs.writeFile("README.md", updatedMd, "utf-8", (err) => {
+      if (err) {
+        throw err;
+      }
+    });
+  });
+};
+fetchPosts();

--- a/JavaScript/Update_README_With_Hashnode_Blogs/update_readme.js
+++ b/JavaScript/Update_README_With_Hashnode_Blogs/update_readme.js
@@ -1,8 +1,12 @@
 const fetch = require("node-fetch");
 const fs = require("fs");
+const numberOfPosts = 3;
+const blogURL = "your Hashnode blog URL";
+const username = "your Hashnode username";
+
 const query = `
     {
-      user(username: "<your Hashnode username>") {
+      user(username: "${username}") {
         publication {
           posts{
             slug
@@ -13,7 +17,7 @@ const query = `
     }
   `;
 
-const fetchPosts = async () => {
+const fetchPosts = async (numberOfPosts) => {
   const result = await fetch("https://api.hashnode.com", {
     method: "POST",
     headers: {
@@ -22,15 +26,35 @@ const fetchPosts = async () => {
     body: JSON.stringify({ query }),
   });
   const response = await result.json();
-  const posts = response.data.user.publication.posts.slice(0, 3);
-  const postsToShow = `\n - [${posts[0].title}](<you hashnode blog URL>/${posts[0].slug})\n - [${posts[1].title}](<you hashnode blog URL>/${posts[1].slug})\n - [${posts[2].title}](<you hashnode blog URL>/${posts[2].slug})\n\n`;
+  
+  //This log will be printed in the action's log, under the Run Script section
+  console.log(
+    "Posts received from Hashnode API as a response:",
+    response.data.user.publication.posts
+  );
+
+  const posts = response.data.user.publication.posts.slice(0, numberOfPosts);
+  let postsToShow = "";
+  for (i = 0; i < numberOfPosts && i < response.data.user.publication.posts.length; i++) {
+    if (i != numberOfPosts - 1) {
+      postsToShow += `\n - [${posts[i].title}](${blogURL}/${posts[i].slug})`;
+    } else {
+      postsToShow += `\n - [${posts[i].title}](${blogURL}/${posts[i].slug})\n`;
+    }
+  }
+
+  //This log will be printed in the action's log, under the Run Script section
+  console.log(
+    "If any changes found among these lines, will be updated in README.md:",
+    postsToShow
+  );
+
   fs.readFile("README.md", "utf-8", (err, data) => {
     if (err) {
       throw err;
     }
-    console.log(postsToShow);
     const updatedMd = data.replace(
-      // To replace texts or blogs between Latest Blogs and Contributors Section
+      // To replace texts or blogs between `Latest Blogs` and `## This Point Won't Be Edited` Section
       /(?<=Latest Blogs\n)[\s\S]*(?=\#\#\ This Point Won't Be Edited)/gim,
       postsToShow
     );
@@ -41,4 +65,4 @@ const fetchPosts = async () => {
     });
   });
 };
-fetchPosts();
+fetchPosts(numberOfPosts);


### PR DESCRIPTION
# Description

I have added a script to auto update readme by recent blogs from **Hashnode**. This is script can be customized in many ways.
I have tested this script in my fork repo. 

Fixes #540 

# Tests
[action link](https://github.com/mdPial/Rotten-Scripts/runs/2259344973?check_suite_focus=true)
[branch link](https://github.com/mdPial/Rotten-Scripts/tree/demo)


## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines(Clean Code) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have created a helpful and easy to understand `README.md`
