### PR TITLE
replaced exit() with sys.exit()

### DIFF
--- a/Python/Download_Instagram_Videos/download_instagram_videos.py
+++ b/Python/Download_Instagram_Videos/download_instagram_videos.py
@@ -15,7 +15,7 @@ def downloadVideo(postId):
     # checking if the post exists
     if url.status_code == 404:
         print("Specified post not found")
-        exit()
+        sys.exit()
 
     # extracting data in json format
     jsonData = json.loads(
@@ -31,7 +31,7 @@ def downloadVideo(postId):
     isVideo = data["is_video"]
     if not isVideo and not multiplePosts:
         print("No Videos found")
-        exit()
+        sys.exit()
 
     # adding valid videos to the list named videos
     if isVideo:

--- a/Python/Encrypt_Text/encrypt_text.py
+++ b/Python/Encrypt_Text/encrypt_text.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import argparse
+import sys
 
 
 def main(text, hashType):
@@ -22,7 +23,7 @@ def main(text, hashType):
         myHash = hashlib.sha512(encoder).hexdigest()
     else:
         print("[!] The script does not support this hash type")
-        exit(0)
+        sys.exit(0)
     print("Your hash is: ", myHash)
 
 

--- a/Python/Facebook_Video_Downloader/script.py
+++ b/Python/Facebook_Video_Downloader/script.py
@@ -1,4 +1,6 @@
 # ALL Imports
+import sys
+
 from tqdm import tqdm
 from requests import get, HTTPError, ConnectionError
 from re import findall
@@ -19,12 +21,12 @@ def get_video_downloadlink(url):
         a = findall("/video_redirect/", r.text)
         if len(a) == 0:
             print("[!] Video Not Found...")
-            exit(0)
+            sys.exit(0)
         else:
             return unquote(r.text.split("?src=")[1].split('"')[0])
     except (HTTPError, ConnectionError):
         print("[x] Invalid URL")
-        exit(1)
+        sys.exit(1)
 
 
 def download_video(url):

--- a/Python/Find_all_Links/find_all_links.py
+++ b/Python/Find_all_Links/find_all_links.py
@@ -31,7 +31,7 @@ def extractLinks(url):
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         help()
-        exit(0)
+        sys.exit(0)
 
     url = sys.argv[1]
     extractLinks(url)

--- a/Python/Get_Current_Weather/get_current_weather.py
+++ b/Python/Get_Current_Weather/get_current_weather.py
@@ -15,7 +15,7 @@ api_key = "c4129d312f42336xxxxxe5b8c65e3647"
 argumentList = sys.argv
 if len(argumentList) < 3:
     print("Please enter the city name and units format")
-    exit()
+    sys.exit()
 
 # base_url variable to store url
 base_url = "http://api.openweathermap.org/data/2.5/weather?"

--- a/Python/Hash_The_File/hash_the_file.py
+++ b/Python/Hash_The_File/hash_the_file.py
@@ -31,7 +31,7 @@ def help():
 
 if len(sys.argv) < 2:
     help()
-    exit(0)
+    sys.exit(0)
 
 offset = 1
 flag = False
@@ -49,7 +49,7 @@ if flag:
         hsh = HASH_MAP[flag]
     except KeyError:
         print("Invalid flag", flag)
-        exit(1)
+        sys.exit(1)
     except:
         raise
 else:
@@ -60,7 +60,7 @@ filenames = sys.argv[offset:]
 
 if len(filenames) == 0:
     help()
-    exit(1)
+    sys.exit(1)
 
 for filename in filenames:
     fd = open(filename, "r")

--- a/Python/Mass_Email_Sender/MassEmailSender/engine.py
+++ b/Python/Mass_Email_Sender/MassEmailSender/engine.py
@@ -1,3 +1,4 @@
+import sys
 from smtplib import SMTP
 from email.mime.multipart import MIMEMultipart
 import mimetypes
@@ -63,7 +64,7 @@ class MailEngine:
             print(
                 "-----+------+------+------+------+------+------+------+------+------+------\n"
             )
-            exit()
+            sys.exit()
 
     def attachFile(self):
         """Attach file:

--- a/Python/Mass_Email_Sender/MassEmailSender/utils.py
+++ b/Python/Mass_Email_Sender/MassEmailSender/utils.py
@@ -1,3 +1,5 @@
+import sys
+
 import pandas as pd
 import os
 from pathlib import Path
@@ -85,7 +87,7 @@ def sendMail(SUBJECT, template, data_path):
         print("Check if you registered your credentials....")
         print("Check your input paths....")
         print("------+------+-------+-------+------+------+------+------+------+------")
-        exit()
+        sys.exit()
 
 
 """Render:
@@ -135,7 +137,7 @@ def render(SUBJECT, senderMail, senderPassword, reciever_email_list, template):
             print(
                 "------+------+-------+-------+------+------+------+------+------+------"
             )
-            exit()
+            sys.exit()
 
     except Exception as e:
         print("------+------+-------+-------+------+------+------+------+------+------")
@@ -144,7 +146,7 @@ def render(SUBJECT, senderMail, senderPassword, reciever_email_list, template):
         print("File not found Error")
         print("Improper file path given....Check input again")
         print("------+------+-------+-------+------+------+------+------+------+------")
-        exit()
+        sys.exit()
 
 
 """Render HTML:
@@ -194,7 +196,7 @@ def renderHTML(Subject, senderMail, senderPassword, reciever_email_list, body_ms
         print(
             "-----+------+------+------+------+------+------+------+------+------+------"
         )
-        exit()
+        sys.exit()
 
     except Exception as e:
         print(
@@ -225,7 +227,7 @@ def renderHTML(Subject, senderMail, senderPassword, reciever_email_list, body_ms
         )
         print("Exiting program...\n")
         print("------+------+-------+-------+------+------+------+------+------+------")
-        exit()
+        sys.exit()
 
 
 """Render TEXT:
@@ -275,7 +277,7 @@ def renderTXT(Subject, senderMail, senderPassword, reciever_email_list, body_msg
         print(
             "-----+------+------+------+------+------+------+------+------+------+------"
         )
-        exit()
+        sys.exit()
 
     except Exception as e:
         print(
@@ -306,4 +308,4 @@ def renderTXT(Subject, senderMail, senderPassword, reciever_email_list, body_msg
         )
         print("Exiting program...\n")
         print("------+------+-------+-------+------+------+------+------+------+------")
-        exit()
+        sys.exit()

--- a/Python/Mass_Email_Sender/mass_email_sender.py
+++ b/Python/Mass_Email_Sender/mass_email_sender.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 import time
 from MassEmailSender.utils import register, sendMail
 
@@ -82,7 +83,7 @@ def main():
                 print(
                     "------+------+-------+-------+------+------+------+------+------+------"
                 )
-                exit()
+                sys.exit()
         else:
             print(
                 "------+------+-------+-------+------+------+------+------+------+------"
@@ -96,7 +97,7 @@ def main():
             print(
                 "------+------+-------+-------+------+------+------+------+------+------"
             )
-            exit()
+            sys.exit()
 
     except Exception as e:
         print("------+------+-------+-------+------+------+------+------+------+------")
@@ -104,7 +105,7 @@ def main():
         print("------+------+-------+-------+------+------+------+------+------+------")
         print("Command not found. Check the input commands again.\n")
         print("------+------+-------+-------+------+------+------+------+------+------")
-        exit()
+        sys.exit()
 
 
 if __name__ == "__main__":

--- a/Python/Meet_Strangers/meet_strangers.py
+++ b/Python/Meet_Strangers/meet_strangers.py
@@ -1,5 +1,5 @@
 # Python Script to spot strangers on a Public WiFi Network by scrapping their MAC Addresses and storing them in a Text File
-
+import sys
 from os import path
 from re import compile, findall
 from subprocess import Popen, PIPE
@@ -36,7 +36,7 @@ def main():
             continue
 
         if user_input in "eE":
-            exit()
+            sys.exit()
         if user_input in "clipboard":
             clipboard()
 
@@ -69,4 +69,4 @@ try:
 except KeyboardInterrupt:
 
     print()
-    exit()
+    sys.exit()

--- a/Python/Send_Email_Using_Gmail_Api/script.py
+++ b/Python/Send_Email_Using_Gmail_Api/script.py
@@ -2,6 +2,7 @@ import os.path
 import pickle
 import base64
 import argparse
+import sys
 
 from email.mime.text import MIMEText
 from googleapiclient.discovery import build
@@ -75,7 +76,7 @@ def main():
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
         print("Please run auth.py first to authorizer")
-        exit(1)
+        sys.exit(1)
 
     service = build("gmail", "v1", credentials=creds)
 

--- a/Python/Shutdown_Your_System/shutdown_your_system.py
+++ b/Python/Shutdown_Your_System/shutdown_your_system.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 
 def main():
@@ -8,7 +9,7 @@ def main():
     elif x == "2":
         cancel()
     elif x == "3":
-        exit()
+        sys.exit()
     else:
         print("Invalid! option")
 

--- a/Python/Sports_Score_Updates/sports_score_updates.py
+++ b/Python/Sports_Score_Updates/sports_score_updates.py
@@ -18,7 +18,7 @@ sports_dict = {
 argumentList = sys.argv
 if len(argumentList) < 2:
     print("Please enter a sport")
-    exit()
+    sys.exit()
 
 if len(argumentList) == 2:
     sport = argumentList[1].lower()

--- a/Python/Time_Conversion/time_conversion.py
+++ b/Python/Time_Conversion/time_conversion.py
@@ -1,3 +1,5 @@
+import sys
+
 from pytz import timezone, country_timezones
 from datetime import datetime, timedelta
 import argparse
@@ -17,7 +19,7 @@ country = args.country
 
 if not location and (not country):
     print("Please enter either location or the country code")
-    exit()
+    sys.exit()
 
 if country:
     code = country_timezones(country)


### PR DESCRIPTION
# Description

The exit or quit functions don't exist at the top-level if python is started with the -S flag, and will raise an error. Use sys.exit() instead. exit() is used and will fail if the python is run with the -S option, where as sys.exit() is guaranteed to work, regardless of the interpreter options.

Fixes #1253

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
-
# Checklist:

- [ ] My code follows the style guidelines(Clean Code) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have created a helpful and easy to understand `README.md`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests/screenshots(if any) that prove my fix is effective or that my feature works
