### PR TITLE
Fix for: Useless `return` detected [PYL-R1711]

### DIFF
--- a/Python/Execution_Time/stopwatch.py
+++ b/Python/Execution_Time/stopwatch.py
@@ -17,16 +17,15 @@ class Stopwatch:
         else:
             # Default to tenths of a second.
             self.__precision__ = 1
-        return
 
     def start(self):
         # Start the stopwatch.
         if not self.state == "Stopped":
             print("Stopwatch is already running.")
-            return
+            return None
+
         self.__startTime__ = time.time()
         self.state = "Started"
-        return
 
     def lap(self):
         # Start tracking a new lap.
@@ -35,7 +34,6 @@ class Stopwatch:
         self.__currentLap__ = 0
         self.__startTime__ = time.time()
         self.__update__()
-        return
 
     def stop(self):
         # Stop/Pause the stopwatch without clearing it.
@@ -44,7 +42,6 @@ class Stopwatch:
         else:
             self.__update__()
             self.state = "Stopped"
-        return
 
     def reset(self):
         # Reset the entire stopwatch back to zero.
@@ -53,7 +50,6 @@ class Stopwatch:
         self.laps = []
         self.summary = None
         self.state = "Stopped"
-        return
 
     def __update__(self):
         # Internal function to update stopwatch summary.
@@ -93,4 +89,3 @@ class Stopwatch:
                 )
             ).rjust(7)
         )
-        return

--- a/Python/Subdomain_Finder/subdomain_finder.py
+++ b/Python/Subdomain_Finder/subdomain_finder.py
@@ -14,10 +14,8 @@ def readTextFile(textFilename):
     inputFile = open(os.path.join(sys.path[0], textFilename), "r")
     available_subdomains = inputFile.read().splitlines()
 
-    inputFile.close()
-    return
-
-
+    inputFile.close()\
+    
 def findSubdomains(userDomain, available_subdomains, size):
     """This function is used to find possible subdomains"""
     subdomains = []


### PR DESCRIPTION
# Description

Fix for: Useless `return` detected [PYL-R1711]
Found at: [deepsource](https://deepsource.io/gh/HarshCasper/Rotten-Scripts/issue/PYL-R1711/occurrences)

Fixes #(PYL-R1711)

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines(Clean Code) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests/screenshots(if any) that prove my fix is effective or that my feature works
