### PR TITLE
`Object.prototype` builtins should not be used directly

### DIFF
--- a/JavaScript/Twitter_Unfollowers/Twitter_Unfollowers.js
+++ b/JavaScript/Twitter_Unfollowers/Twitter_Unfollowers.js
@@ -73,7 +73,7 @@ const init = async () => {
     dbData = (dbData === "" || dbData.length == 0) ? "{}" : dbData;
     dbData = JSON.parse(dbData);
 
-    if (dbData.hasOwnProperty(user.name)) {
+    if (Object.prototype.hasOwnProperty.call(dbData, "user.name")) {
         // display basic info
         displayUser(user);
 


### PR DESCRIPTION
It is preferable to call certain Object.prototype methods through Object on object instances instead of using the builtins directly.

# Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.

Fixes #1278

Replace `#` with the issue number which is fixed in this PR

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation Update

# Checklist:

- [ ] My code follows the style guidelines(Clean Code) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have created a helpful and easy to understand `README.md`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests/screenshots(if any) that prove my fix is effective or that my feature works
