### PR TITLE
Using literal syntax to create the data structure

### DIFF
--- a/Python/Automate_Image_Caption/caption_generator_Inception.py
+++ b/Python/Automate_Image_Caption/caption_generator_Inception.py
@@ -73,7 +73,7 @@ def load_descriptions(doc):
     :param doc: Caption text files
     :return: Captions mapped to images
     """
-    mapping = dict()
+    mapping = {}
     # process lines
     for line in doc.split("\n"):
 
@@ -93,7 +93,7 @@ def load_descriptions(doc):
 
         # create the list if needed
         if image_id not in mapping:
-            mapping[image_id] = list()
+            mapping[image_id] = []
 
         # store description
         mapping[image_id].append(image_desc)
@@ -164,7 +164,7 @@ def save_descriptions(descriptions, filename):
     :param descriptions: Clean descriptions
     :param filename: Path of File
     """
-    lines = list()
+    lines = []
     for key, desc_list in descriptions.items():
         for desc in desc_list:
             lines.append(key + " " + desc)
@@ -182,7 +182,7 @@ def load_set(filename):
     :param filename: path to file to be loaded
     """
     doc = load_doc(filename)
-    dataset = list()
+    dataset = []
     # process line by line
     for line in doc.split("\n"):
         # skip empty lines
@@ -242,7 +242,7 @@ def load_clean_descriptions(filename, dataset):
     """
     # load document
     doc = load_doc(filename)
-    descriptions = dict()
+    descriptions = {}
     for line in doc.split("\n"):
         # split line by white space
         tokens = line.split()
@@ -252,7 +252,7 @@ def load_clean_descriptions(filename, dataset):
         if image_id in dataset:
             # create list
             if image_id not in descriptions:
-                descriptions[image_id] = list()
+                descriptions[image_id] = []
             # wrap description in tokens
             desc = "startseq " + " ".join(image_desc) + " endseq"
             # store
@@ -388,7 +388,7 @@ def to_lines(descriptions):
     :param descriptions: Clean Description
     :return: List of all descriptions
     """
-    all_desc = list()
+    all_desc = []
     for key, value in descriptions.keys():
         [all_desc.append(d) for d in descriptions[key]]
     return all_desc
@@ -419,7 +419,7 @@ def data_generator(descriptions, photos, wordtoix, max_length, num_photos_per_ba
     :param num_photos_per_batch: Batch Size oof images
     :return:
     """
-    X1, X2, y = list(), list(), list()
+    X1, X2, y = [], [], []
     n = 0
     # loop for ever over images
     while 1:
@@ -448,7 +448,7 @@ def data_generator(descriptions, photos, wordtoix, max_length, num_photos_per_ba
             # yield the batch data
             if n == num_photos_per_batch:
                 yield [array(X1), array(X2)], array(y)
-                X1, X2, y = list(), list(), list()
+                X1, X2, y = [], [], []
                 n = 0
 
 

--- a/Python/Automate_Image_Caption/caption_generator_Xception.py
+++ b/Python/Automate_Image_Caption/caption_generator_Xception.py
@@ -107,7 +107,7 @@ with tf.device("/gpu:0"):
         :param descriptions: Captions
         :param filename: Destination file
         """
-        lines = list()
+        lines = []
         for key, desc_list in descriptions.items():
             for desc in desc_list:
                 lines.append(key + "\t" + desc)
@@ -292,7 +292,7 @@ with tf.device("/gpu:0"):
         :param feature: Features of the images
         :return: Data generated in sequence of Arrays
         """
-        X1, X2, y = list(), list(), list()
+        X1, X2, y = [], [], []
         # walk through each description for the image
         for desc in desc_list:
             # encode the sequence

--- a/Python/Google_News_Scrapper/app.py
+++ b/Python/Google_News_Scrapper/app.py
@@ -10,8 +10,8 @@ def get_google_news_result(term, count):
     )
     items = obj.getElementsByTagName("item")
     # Storing the Titles and Links
-    titles = list()
-    links = list()
+    titles = []
+    links = []
     for item in items[:count]:
         title, link = "", ""
         for node in item.childNodes:

--- a/Python/Image_Steganography/steganography.py
+++ b/Python/Image_Steganography/steganography.py
@@ -30,7 +30,7 @@ def encode(img):
     len_secret_text_binary = len(secret_text_binary)
 
     imdata = iter(img.getdata())
-    changed_pixels = list()
+    changed_pixels = []
 
     for i in range(len_secret_text_binary):
         pixels = [

--- a/Python/Linkedin_Learning_Video_Downloader/script.py
+++ b/Python/Linkedin_Learning_Video_Downloader/script.py
@@ -28,7 +28,7 @@ def videos_downloader_main(browser, course_url):
     """
     login(browser, "https://www.linkedin.com/learning/")
     time.sleep(1)
-    video_urls = list()
+    video_urls = []
     browser.get(course_url)
     time.sleep(2)
 
@@ -39,7 +39,7 @@ def videos_downloader_main(browser, course_url):
         video_urls.append(video_url)
 
     # Dictionary will store name of courses and their source url
-    video_srcs_wth_name = dict()
+    video_srcs_wth_name = {}
 
     # loop through the video urls to find the source of videos
     for video_url in video_urls:

--- a/Python/Ports_Scan/ports_kill.py
+++ b/Python/Ports_Scan/ports_kill.py
@@ -8,10 +8,10 @@ def get_pid():
     port = int(sys.argv[1])
     # Using psutil functionality
     for con in connections:
-        if con.raddr != tuple():
+        if con.raddr != ():
             if con.raddr.port == port:
                 return con.pid, con.status
-        if con.laddr != tuple():
+        if con.laddr != ():
             if con.laddr.port == port:
                 return con.pid, con.status
     return -1

--- a/Python/Slideshare_Slides_Downloader/slide_downloader.py
+++ b/Python/Slideshare_Slides_Downloader/slide_downloader.py
@@ -13,7 +13,7 @@ def get_image_urls_list(url):
         r"chromedriver_win32\chromedriver.exe"
     )  # Web driver loaded
     driver.get(url)
-    url_list = list()
+    url_list = []
     for image in driver.find_elements_by_class_name("slide_image"):
         try:
             # 'data-full' contains the url of the image
@@ -31,7 +31,7 @@ def download_individual_image(url_list):
     print("Downloading individual images...")
     os.mkdir("new_folder")
     os.chdir(os.path.join(os.getcwd() + "/new_folder"))
-    image_paths = list()
+    image_paths = []
     for i, url in enumerate(url_list):
         filename = str(i) + ".jpg"
         # downloads image from url with filename to current directory


### PR DESCRIPTION
Using the literal syntax can give minor performance bumps compared to using function calls to create dict, list and tuple.

```python

In [1]: timeit.timeit(stmt="dict()", number=100000000)
Out[1]: 9.560388602000103

In [2]: timeit.timeit(stmt="{}", number=100000000)
Out[2]: 1.685333584000091

In [3]: timeit.timeit(stmt="tuple()", number=100000000)
Out[3]: 4.509182139000131

In [4]: timeit.timeit(stmt="()", number=100000000)
Out[4]: 0.5455615430000762

In [5]: timeit.timeit(stmt="list()", number=100000000)
Out[5]: 7.356000728000254

In [6]: timeit.timeit(stmt="[]", number=100000000)
Out[6]: 1.573771306999788

```

This is because here, the name dict must be looked up in the global scope in case it has been rebound. Same goes for the other two types list() and tuple().